### PR TITLE
Change remote methods to resource methods

### DIFF
--- a/fhir/Dependencies.toml
+++ b/fhir/Dependencies.toml
@@ -348,7 +348,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.clients.fhir"
-version = "1.0.1"
+version = "1.0.2-snapshot"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},

--- a/fhir/fhir_connector.bal
+++ b/fhir/fhir_connector.bal
@@ -71,7 +71,7 @@ public isolated client class FHIRConnector {
     # + summary - The subset of the resource content to be returned
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Get resource by the logical ID"}
-    remote isolated function getById(@display {label: "Resource Type"} ResourceType|string 'type,
+    isolated resource function get read/id(@display {label: "Resource Type"} ResourceType|string 'type,
             @display {label: "Logical ID"} string id,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = (),
             @display {label: "Summary"} SummaryType? summary = ())
@@ -102,7 +102,7 @@ public isolated client class FHIRConnector {
     # + summary - The subset of the resource content to be returned
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Get resource by version"}
-    remote isolated function getByVersion(@display {label: "Resource Type"} ResourceType|string 'type,
+    isolated resource function get read/'version(@display {label: "Resource Type"} ResourceType|string 'type,
             @display {label: "Logical ID"} string id,
             @display {label: "Version ID"} string 'version,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = (),
@@ -133,7 +133,7 @@ public isolated client class FHIRConnector {
     # + returnPreference - To specify the content of the return response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Update resource"}
-    remote isolated function update(@display {label: "Resource data"} json|xml data,
+    isolated resource function put fhirResource(@display {label: "Resource data"} json|xml data,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = (),
             @display {label: "Return Preference Type"} PreferenceType returnPreference = MINIMAL)
                                             returns FHIRResponse|FHIRError {
@@ -170,7 +170,7 @@ public isolated client class FHIRConnector {
     # + returnPreference - To specify the content of the return response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Patch resource"}
-    remote isolated function patch(@display {label: "Resource Type"} ResourceType|string 'type,
+    isolated resource function patch fhirResource(@display {label: "Resource Type"} ResourceType|string 'type,
             @display {label: "Logical ID"} string id,
             @display {label: "Resource data"} json|xml data,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = (),
@@ -200,7 +200,7 @@ public isolated client class FHIRConnector {
     # + id - The logical id of the resource 
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Delete  resource"}
-    remote isolated function delete(@display {label: "Resource Type"} ResourceType|string 'type,
+    isolated resource function delete fhirResource(@display {label: "Resource Type"} ResourceType|string 'type,
             @display {label: "Logical ID"} string id)
                                             returns FHIRResponse|FHIRError {
         string requestURL = SLASH + 'type + SLASH + id;
@@ -227,7 +227,7 @@ public isolated client class FHIRConnector {
     # + returnMimeType - The MIME type of the response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Get instance history"}
-    remote isolated function getInstanceHistory(@display {label: "Resource Type"} ResourceType|string 'type,
+    isolated resource function get history/instance(@display {label: "Resource Type"} ResourceType|string 'type,
             @display {label: "Logical ID"} string id,
             @display {label: "History Search Parameters"} HistorySearchParameters parameters = {},
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
@@ -256,7 +256,7 @@ public isolated client class FHIRConnector {
     # + returnPreference - To specify the content of the return response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Create resource"}
-    remote isolated function create(@display {label: "Resource data"} json|xml data,
+    isolated resource function post fhirResource(@display {label: "Resource data"} json|xml data,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = (),
             @display {label: "Return Preference Type"} PreferenceType returnPreference = MINIMAL)
                                             returns FHIRResponse|FHIRError {
@@ -285,7 +285,7 @@ public isolated client class FHIRConnector {
     # + returnMimeType - The MIME type of the response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "search resource"}
-    remote isolated function search(@display {label: "Resource Type"} ResourceType|string 'type,
+    isolated resource function get search/'type(@display {label: "Resource Type"} ResourceType|string 'type,
             @display {label: "Search Parameters"} SearchParameters|map<string[]>? searchParameters = (),
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
                                     returns FHIRResponse|FHIRError {
@@ -313,7 +313,7 @@ public isolated client class FHIRConnector {
     # + returnMimeType - The MIME type of the response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Get history for a type"}
-    remote isolated function getHistory(@display {label: "Resource Type"} ResourceType|string 'type,
+    isolated resource function get history/'type(@display {label: "Resource Type"} ResourceType|string 'type,
             @display {label: "History Search Parameters"} HistorySearchParameters parameters = {},
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
                             returns FHIRResponse|FHIRError {
@@ -341,7 +341,7 @@ public isolated client class FHIRConnector {
     # + uriParameters - The additional parameters like _summary, _elements, refer the server capabilities
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Get capability statement"}
-    remote isolated function getConformance(@display {label: "Mode"} ModeType mode = FULL,
+    isolated resource function get metadata(@display {label: "Mode"} ModeType mode = FULL,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = (),
             @display {label: "Return MIME Type"} map<anydata>? uriParameters = ())
                                             returns FHIRResponse|FHIRError {
@@ -369,7 +369,7 @@ public isolated client class FHIRConnector {
     # + returnMimeType - The MIME type of the response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Get all history"}
-    remote isolated function getAllHistory(@display {label: "History Search Parameters"} HistorySearchParameters parameters = {},
+    isolated resource function get history(@display {label: "History Search Parameters"} HistorySearchParameters parameters = {},
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
                                             returns FHIRResponse|FHIRError {
         string requestUrl = SLASH + _HISTORY + setHistoryParams(parameters, returnMimeType);
@@ -395,7 +395,7 @@ public isolated client class FHIRConnector {
     # + returnMimeType - The MIME type of the response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Search across all resources"}
-    remote isolated function searchAll(@display {label: "Search Parameters"} SearchParameters|map<string[]> searchParameters,
+    isolated resource function get search(@display {label: "Search Parameters"} SearchParameters|map<string[]> searchParameters,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
                                         returns FHIRResponse|FHIRError {
         string requestUrl = QUESTION_MARK + setSearchParams(searchParameters, returnMimeType);
@@ -421,7 +421,7 @@ public isolated client class FHIRConnector {
     # + returnMimeType - The MIME type of the response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Batch operation"}
-    remote isolated function batchRequest(@display {label: "Resource data"} json|xml data,
+    isolated resource function post batch(@display {label: "Resource data"} json|xml data,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
                                         returns FHIRResponse|FHIRError {
         string requestUrl = QUESTION_MARK + setFormatParameters(returnMimeType);
@@ -452,7 +452,7 @@ public isolated client class FHIRConnector {
     # + returnMimeType - The MIME type of the response
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Transaction operation"}
-    remote isolated function 'transaction(@display {label: "Resource data"} json|xml data,
+    isolated resource function post 'transaction(@display {label: "Resource data"} json|xml data,
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
                                         returns FHIRResponse|FHIRError {
         string requestUrl = QUESTION_MARK + setFormatParameters(returnMimeType);
@@ -483,7 +483,7 @@ public isolated client class FHIRConnector {
     # + currentBundle - Current bundle resource should be generated as a result of invoking a connector method. This is to ensure consistency of urlRewrite feature. If the urlRewrite is enabled, the current bundles' urls should be rewritten. 
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Get next page of a bundle resource"}
-    remote isolated function nextBundle(@display {label: "Current Bundle"} FHIRResponse|json|xml currentBundle)
+    isolated resource function get bundle/next(@display {label: "Current Bundle"} FHIRResponse|json|xml currentBundle)
                                         returns FHIRResponse|FHIRError? {
         do {
             // If the urlRewrite is enabled, replacementURL is of type string, we can cast it safely here.
@@ -511,7 +511,7 @@ public isolated client class FHIRConnector {
     # + currentBundle - Current bundle resource should be generated as a result of invoking a connector method. This is to ensure consistency of urlRewrite feature. If the urlRewrite is enabled, the current bundles' urls should be rewritten. 
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Get previous page of a bundle resource"}
-    remote isolated function previousBundle(@display {label: "Current Bundle"} FHIRResponse|json|xml currentBundle)
+    isolated resource function get bundle/previous(@display {label: "Current Bundle"} FHIRResponse|json|xml currentBundle)
                                         returns FHIRResponse|FHIRError? {
         do {
             // If the urlRewrite is enabled, replacementURL is of type string, we can cast it safely here.
@@ -541,7 +541,7 @@ public isolated client class FHIRConnector {
     # + bulkExportParameters - Bulk export parameters
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Start bulk data export process"}
-    remote isolated function bulkExport(@display {label: "Bulk export level"} BulkExportLevel bulkExportLevel,
+    isolated resource function get bulk/export(@display {label: "Bulk export level"} BulkExportLevel bulkExportLevel,
             @display {label: "Group ID to be exported"} string? groupId = (),
             @display {label: "Bulk export parameters"} BulkExportParameters? bulkExportParameters = ())
                                         returns FHIRResponse|FHIRError {
@@ -584,7 +584,7 @@ public isolated client class FHIRConnector {
     # + contentLocation - Bulk status polling url. Found in the response header of the kickoff request
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Check bulk data export progress"}
-    remote isolated function bulkStatus(@display {label: "Bulk status polling url"} string contentLocation)
+    isolated resource function get bulk/status(@display {label: "Bulk status polling url"} string contentLocation)
                                         returns FHIRResponse|FHIRError {
         do {
             // If the urlRewrite is enabled, replacementURL is of type string, we can cast it safely here.
@@ -611,7 +611,7 @@ public isolated client class FHIRConnector {
     # + contentLocation - Bulk status polling url. Found in the response header of the kickoff request
     # + return - If successful, FhirResponse record else FhirError record
     @display {label: "Check bulk data export progress"}
-    remote isolated function bulkDataDelete(@display {label: "Bulk status polling url"} string contentLocation)
+    isolated resource function delete bulk/export(@display {label: "Bulk status polling url"} string contentLocation)
                                         returns FHIRResponse|FHIRError {
         do {
             // If the urlRewrite is enabled, replacementURL is of type string, we can cast it safely here.
@@ -639,7 +639,7 @@ public isolated client class FHIRConnector {
     # + additionalHeaders - Additional headers sent with the request
     # + return - If successful, FhirBulkFileResponse record else FhirError record
     @display {label: "Get exported file as a byte[] stream"}
-    remote isolated function bulkFile(@display {label: "Exported file url"} string fileUrl,
+    isolated resource function get bulk/file(@display {label: "Exported file url"} string fileUrl,
             @display {label: "Additional headers sent with the request"} map<string>? additionalHeaders = ())
                                         returns FHIRBulkFileResponse|FHIRError {
         do {

--- a/fhir/tests/test.bal
+++ b/fhir/tests/test.bal
@@ -52,24 +52,24 @@ function testUrlRewrite() returns FHIRError? {
 
     // json
     // Connector config set to enable url rewrite
-    FHIRResponse res1 = check urlRewriteConnector->getConformance();
+    FHIRResponse res1 = check urlRewriteConnector->/metadata();
     test:assertEquals(res1.'resource, testCapabilityStatementJsonUrlRewritten, "Failed to rewrite url and return correct resource.");
 
     // Override connector config to disable url rewrite
-    FHIRResponse res2 = check fhirConnector->getConformance();
+    FHIRResponse res2 = check fhirConnector->/metadata();
     test:assertEquals(res2.'resource, testCapabilityStatementJson, "Failed to return correct resource.");
 
     // xml
     // Connector config set to enable url rewrite
-    FHIRResponse res3 = check urlRewriteConnector->getConformance(returnMimeType = FHIR_XML);
+    FHIRResponse res3 = check urlRewriteConnector->/metadata(returnMimeType = FHIR_XML);
     test:assertEquals(res3.'resource, testCapabilityStatementXmlUrlRewritten, "Failed to rewrite url and return correct resource.");
 
     // Override connector config to disable url rewrite
-    FHIRResponse res4 = check fhirConnector->getConformance(returnMimeType = FHIR_XML);
+    FHIRResponse res4 = check fhirConnector->/metadata(returnMimeType = FHIR_XML);
     test:assertEquals(res4.'resource, testCapabilityStatementXml, "Failed to return correct resource.");
 
     // Testing URL rewrite on headers
-    FHIRResponse res5 = check urlRewriteConnector->bulkExport(EXPORT_SYSTEM);
+    FHIRResponse res5 = check urlRewriteConnector->/bulk/export(EXPORT_SYSTEM);
     string rewrittenPollingUrl = res5.serverResponseHeaders["content-location"] ?: "";
     test:assertEquals(rewrittenPollingUrl, string `${replacementUrl}/exportStatus/1`, "Failed to url rewrite headers");
 
@@ -79,17 +79,17 @@ function testUrlRewrite() returns FHIRError? {
 function testGetById() returns FHIRError? {
 
     // Format param is set to default
-    FHIRResponse result1 = check fhirConnector->getById(PATIENT, "pat1");
+    FHIRResponse result1 = check fhirConnector->/read/id(PATIENT, "pat1");
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testGetResourceDataJson, "Failed to return the resource data.");
 
     // Format param is set to xml
-    FHIRResponse result2 = check fhirConnector->getById(PATIENT, "pat1", returnMimeType = FHIR_XML);
+    FHIRResponse result2 = check fhirConnector->/read/id(PATIENT, "pat1", returnMimeType = FHIR_XML);
     test:assertEquals(result2.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testGetResourceDataXml, "Failed to return the resource data.");
 
     // resource doesn't exists
-    FHIRResponse|FHIRError result3 = fhirConnector->getById(PATIENT, "pat170");
+    FHIRResponse|FHIRError result3 = fhirConnector->/read/id(PATIENT, "pat170");
     if result3 is FHIRError {
         if result3 is FHIRServerError {
             test:assertEquals(result3.detail().httpStatusCode, 404, "Failed to return the correct status code");
@@ -108,17 +108,17 @@ function testGetById() returns FHIRError? {
 function testGetByVersion() returns FHIRError? {
 
     // Format param is set to default
-    FHIRResponse result1 = check fhirConnector->getByVersion(PATIENT, "pat1", "100");
+    FHIRResponse result1 = check fhirConnector->/read/'version(PATIENT, "pat1", "100");
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testGetResourceDataJson, "Failed to return the resource data.");
 
     // Format param is set to xml
-    FHIRResponse result2 = check fhirConnector->getByVersion(PATIENT, "pat1", "100", returnMimeType = FHIR_XML);
+    FHIRResponse result2 = check fhirConnector->/read/'version(PATIENT, "pat1", "100", returnMimeType = FHIR_XML);
     test:assertEquals(result2.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testGetResourceDataXml, "Failed to return the resource data.");
 
     // resource doesn't exists
-    FHIRResponse|FHIRError result3 = fhirConnector->getByVersion(PATIENT, "pat1", "101");
+    FHIRResponse|FHIRError result3 = fhirConnector->/read/'version(PATIENT, "pat1", "101");
     if result3 is FHIRError {
         if result3 is FHIRServerError {
             test:assertEquals(result3.detail().httpStatusCode, 404, "Failed to return the correct status code");
@@ -136,22 +136,22 @@ function testGetByVersion() returns FHIRError? {
 @test:Config {}
 function testUpdate() returns FHIRError? {
     // json data
-    FHIRResponse result1 = check fhirConnector->update(testUpdateResourceDataJson);
+    FHIRResponse result1 = check fhirConnector->/fhirResource.put(testUpdateResourceDataJson);
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, locationDetails, "Failed to return location details.");
 
     //xml data 
-    FHIRResponse result2 = check fhirConnector->update(testUpdateResourceDataXml);
+    FHIRResponse result2 = check fhirConnector->/fhirResource.put(testUpdateResourceDataXml);
     test:assertEquals(result2.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, locationDetails, "Failed to return location details.");
 
     //prefer head set to representation
-    FHIRResponse result3 = check fhirConnector->update(testUpdateResourceDataJson, returnPreference = REPRESENTATION);
+    FHIRResponse result3 = check fhirConnector->/fhirResource.put(testUpdateResourceDataJson, returnPreference = REPRESENTATION);
     test:assertEquals(result3.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result3.'resource, testGetResourceDataJson, "Failed to return location details.");
 
     // data doesn't contain id attribute
-    FHIRResponse|FHIRError result4 = fhirConnector->update(testUpdateResourceDataJsonMissingId);
+    FHIRResponse|FHIRError result4 = fhirConnector->/fhirResource.put(testUpdateResourceDataJsonMissingId);
     if result4 is FHIRError {
         if result4 is FHIRConnectorError {
             error? e = result4.detail().errorDetails;
@@ -172,12 +172,12 @@ function testUpdate() returns FHIRError? {
 @test:Config {}
 function testPatch() returns FHIRError? {
     // resource exists
-    FHIRResponse result1 = check fhirConnector->patch(PATIENT, "pat1", testPatchResourceDataXml, patchContentType = FHIR_XML);
+    FHIRResponse result1 = check fhirConnector->/fhirResource.patch(PATIENT, "pat1", testPatchResourceDataXml, patchContentType = FHIR_XML);
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, locationDetails, "Failed to return location details.");
 
     // resource doesn't exists
-    FHIRResponse|FHIRError result2 = fhirConnector->patch(PATIENT, "pat2", testPatchResourceDataXml, patchContentType = FHIR_XML);
+    FHIRResponse|FHIRError result2 = fhirConnector->/fhirResource.patch(PATIENT, "pat2", testPatchResourceDataXml, patchContentType = FHIR_XML);
     if result2 is FHIRError {
         if result2 is FHIRServerError {
             test:assertEquals(result2.detail().httpStatusCode, 404, "Failed to return the correct status code");
@@ -196,11 +196,11 @@ function testPatch() returns FHIRError? {
 @test:Config {}
 function testDelete() returns FHIRError? {
     // requested resource exists
-    FHIRResponse result1 = check fhirConnector->delete(PATIENT, "pat1");
+    FHIRResponse result1 = check fhirConnector->/fhirResource.delete(PATIENT, "pat1");
     test:assertEquals(result1.httpStatusCode, 204, "Failed to return the correct status code");
 
     // resource not found
-    FHIRResponse|FHIRError result2 = fhirConnector->delete(PATIENT, "pat2");
+    FHIRResponse|FHIRError result2 = fhirConnector->/fhirResource.delete(PATIENT, "pat2");
     if result2 is FHIRError {
         if result2 is FHIRServerError {
             test:assertEquals(result2.detail().httpStatusCode, 404, "Failed to return the correct status code");
@@ -219,12 +219,12 @@ function testDelete() returns FHIRError? {
 @test:Config {}
 function testGetInstanceHistory() returns FHIRError? {
     // requested resource exists 
-    FHIRResponse result1 = check fhirConnector->getInstanceHistory(PATIENT, "pat1");
+    FHIRResponse result1 = check fhirConnector->/history/instance(PATIENT, "pat1");
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testGetResourceDataJson, "Failed to return resource bundle");
 
     // requested resource doesn't exits 
-    FHIRResponse|FHIRError result2 = fhirConnector->getInstanceHistory(PATIENT, "pat10");
+    FHIRResponse|FHIRError result2 = fhirConnector->/history/instance(PATIENT, "pat10");
     if result2 is FHIRError {
         if result2 is FHIRServerError {
             test:assertEquals(result2.detail().httpStatusCode, 404, "Failed to return the correct status code");
@@ -243,36 +243,36 @@ function testGetInstanceHistory() returns FHIRError? {
 @test:Config {}
 function testCreate() returns FHIRError? {
     // create with default values
-    FHIRResponse result1 = check fhirConnector->create(testUpdateResourceDataJson);
+    FHIRResponse result1 = check fhirConnector->/fhirResource.post(testUpdateResourceDataJson);
     test:assertEquals(result1.httpStatusCode, 201, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, locationDetails, "Failed to return location details.");
 
     //prefer header set to representation and xml data
-    FHIRResponse result2 = check fhirConnector->create(testUpdateResourceDataXml, returnPreference = REPRESENTATION);
+    FHIRResponse result2 = check fhirConnector->/fhirResource.post(testUpdateResourceDataXml, returnPreference = REPRESENTATION);
     test:assertEquals(result2.httpStatusCode, 201, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testGetResourceDataJson, "Failed to return location details.");
 }
 
 @test:Config {}
 function testSearch() returns FHIRError? {
-    FHIRResponse result1 = check fhirConnector->search(PATIENT);
+    FHIRResponse result1 = check fhirConnector->/search/'type(PATIENT);
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testSearchDataSet1Json, "Failed to return search result bundle.");
 
     // Using default params. urlRewrite set to true
-    FHIRResponse result2 = check urlRewriteConnector->search(PATIENT);
+    FHIRResponse result2 = check urlRewriteConnector->/search/'type(PATIENT);
     test:assertEquals(result2.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testSearchDataSet1JsonUrlRewritten, "Failed to return URL rewritten search result bundle.");
 }
 
 @test:Config {}
 function testGetHistory() returns FHIRError? {
-    FHIRResponse result1 = check fhirConnector->getHistory(PATIENT, parameters = {_count: "5", _since: "2010-05-05"});
+    FHIRResponse result1 = check fhirConnector->/history/'type(PATIENT, parameters = {_count: "5", _since: "2010-05-05"});
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testHistoryDataJson, "Failed to return history result bundle.");
 
     // Using default params. urlRewrite set to true
-    FHIRResponse result2 = check urlRewriteConnector->getHistory(PATIENT, parameters = {_count: "5", _since: "2010-05-05"});
+    FHIRResponse result2 = check urlRewriteConnector->/history/'type(PATIENT, parameters = {_count: "5", _since: "2010-05-05"});
     test:assertEquals(result2.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testHistoryDataJsonUrlRewritten, "Failed to return URL rewritten history result bundle.");
 }
@@ -280,36 +280,36 @@ function testGetHistory() returns FHIRError? {
 @test:Config {}
 function testGetConformance() returns FHIRError? {
     // get full capability statement. urlRewrite set to true 
-    FHIRResponse result1 = check urlRewriteConnector->getConformance();
+    FHIRResponse result1 = check urlRewriteConnector->/metadata();
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testCapabilityStatementJsonUrlRewritten, "Failed to return url rewritten capability statement.");
 
     //returns other types of modes
-    FHIRResponse result2 = check fhirConnector->getConformance(mode = TERMINOLOGY);
+    FHIRResponse result2 = check fhirConnector->/metadata(mode = TERMINOLOGY);
     test:assertEquals(result2.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testCapStatementData, "Failed to return capability statement.");
 }
 
 @test:Config {}
 function testGetAllHistory() returns FHIRError? {
-    FHIRResponse result1 = check fhirConnector->getAllHistory(parameters = {_count: "5"});
+    FHIRResponse result1 = check fhirConnector->/history(parameters = {_count: "5"});
     test:assertEquals(result1.httpStatusCode, http:STATUS_OK, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testHistoryDataJson, "Failed to return history result bundle.");
 
     // Using default params. urlRewrite set to true
-    FHIRResponse result2 = check urlRewriteConnector->getAllHistory(parameters = {_count: "5"});
+    FHIRResponse result2 = check urlRewriteConnector->/history(parameters = {_count: "5"});
     test:assertEquals(result2.httpStatusCode, http:STATUS_OK, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testHistoryDataJsonUrlRewritten, "Failed to return URL rewritten history result bundle.");
 }
 
 @test:Config {}
 function testSearchAll() returns FHIRError? {
-    FHIRResponse result1 = check fhirConnector->searchAll(searchParameters = {_id: ["50"]});
+    FHIRResponse result1 = check fhirConnector->/search(searchParameters = {_id: ["50"]});
     test:assertEquals(result1.httpStatusCode, http:STATUS_OK, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testSearchDataSet2Json, "Failed to return search result bundle.");
 
     // Using default params. urlRewrite set to true
-    FHIRResponse result2 = check urlRewriteConnector->searchAll(searchParameters = {_id: ["50"]});
+    FHIRResponse result2 = check urlRewriteConnector->/search(searchParameters = {_id: ["50"]});
     test:assertEquals(result2.httpStatusCode, http:STATUS_OK, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testSearchDataSet2JsonUrlRewritten, "Failed to return URL rewritten search result bundle.");
 }
@@ -317,17 +317,17 @@ function testSearchAll() returns FHIRError? {
 @test:Config {}
 function testBatchRequest() returns FHIRError? {
     // json request
-    FHIRResponse result1 = check fhirConnector->batchRequest(testBatchDataJson);
+    FHIRResponse result1 = check fhirConnector->/batch.post(testBatchDataJson);
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testBundleDataJson, "Failed to return batch result bundle.");
 
     // xml request
-    FHIRResponse result2 = check fhirConnector->batchRequest(testBatchDataXml);
+    FHIRResponse result2 = check fhirConnector->/batch.post(testBatchDataXml);
     test:assertEquals(result2.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testBundleDataJson, "Failed to return batch result bundle.");
 
     // invalid bundle type
-    FHIRResponse|FHIRError result3 = fhirConnector->batchRequest(testTransactionDataJson);
+    FHIRResponse|FHIRError result3 = fhirConnector->/batch.post(testTransactionDataJson);
     if result3 is FHIRError {
         if result3 is FHIRConnectorError {
             error? e = result3.detail().errorDetails;
@@ -349,12 +349,12 @@ function testBatchRequest() returns FHIRError? {
 @test:Config {}
 function testTransaction() returns FHIRError? {
     // json request
-    FHIRResponse result1 = check fhirConnector->'transaction(testTransactionDataJson);
+    FHIRResponse result1 = check fhirConnector->/'transaction.post(testTransactionDataJson);
     test:assertEquals(result1.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result1.'resource, testBundleDataJson, "Failed to return batch result bundle.");
 
     // invalid bundle type
-    FHIRResponse|FHIRError result2 = fhirConnector->'transaction(testBatchDataJson);
+    FHIRResponse|FHIRError result2 = fhirConnector->/'transaction.post(testBatchDataJson);
     if result2 is FHIRError {
         if result2 is FHIRConnectorError {
             error? e = result2.detail().errorDetails;
@@ -374,10 +374,10 @@ function testTransaction() returns FHIRError? {
 
 @test:Config {}
 function testNextBundle() returns FHIRError? {
-    FHIRResponse initialResultJson = check urlRewriteConnector->search(PATIENT);
+    FHIRResponse initialResultJson = check urlRewriteConnector->/search/'type(PATIENT);
 
     // next bundle exists JSON
-    FHIRResponse? nextBundleJson = check urlRewriteConnector->nextBundle(initialResultJson);
+    FHIRResponse? nextBundleJson = check urlRewriteConnector->/bundle/next(initialResultJson);
 
     if nextBundleJson is FHIRResponse {
         test:assertEquals(nextBundleJson.httpStatusCode, 200, "Failed to return the correct status code");
@@ -388,7 +388,7 @@ function testNextBundle() returns FHIRError? {
     }
 
     // next bundle doesn't exists 
-    FHIRResponse? nextBundle2 = check urlRewriteConnector->nextBundle(nextBundleJson);
+    FHIRResponse? nextBundle2 = check urlRewriteConnector->/bundle/next(nextBundleJson);
     if nextBundle2 is () {
         test:assertTrue(true);
     } else {
@@ -396,8 +396,8 @@ function testNextBundle() returns FHIRError? {
     }
 
     // next bundle exists XML
-    FHIRResponse initialResultXml = check urlRewriteConnector->search(PATIENT, returnMimeType = FHIR_XML);
-    FHIRResponse? nextBundleXml = check urlRewriteConnector->nextBundle(initialResultXml);
+    FHIRResponse initialResultXml = check urlRewriteConnector->/search/'type(PATIENT, returnMimeType = FHIR_XML);
+    FHIRResponse? nextBundleXml = check urlRewriteConnector->/bundle/next(initialResultXml);
 
     if nextBundleXml is FHIRResponse {
         test:assertEquals(nextBundleXml.httpStatusCode, 200, "Failed to return the correct status code");
@@ -412,10 +412,10 @@ function testNextBundle() returns FHIRError? {
 @test:Config {}
 function testPreviousBundle() returns FHIRError?|error {
 
-    FHIRResponse initialResult = check urlRewriteConnector->search(PATIENT);
+    FHIRResponse initialResult = check urlRewriteConnector->/search/'type(PATIENT);
 
     //  previous bundle doesn't exists 
-    FHIRResponse? prevBundle = check urlRewriteConnector->previousBundle(initialResult);
+    FHIRResponse? prevBundle = check urlRewriteConnector->/bundle/previous(initialResult);
     if prevBundle is () {
         test:assertTrue(true);
     } else {
@@ -423,9 +423,9 @@ function testPreviousBundle() returns FHIRError?|error {
     }
 
     // previous bundle exists 
-    FHIRResponse? nextBundle = check urlRewriteConnector->nextBundle(initialResult);
+    FHIRResponse? nextBundle = check urlRewriteConnector->/bundle/next(initialResult);
 
-    FHIRResponse? prevBundle2 = check urlRewriteConnector->previousBundle(nextBundle);
+    FHIRResponse? prevBundle2 = check urlRewriteConnector->/bundle/previous(nextBundle);
     if prevBundle2 is FHIRResponse {
         test:assertEquals(prevBundle2.httpStatusCode, 200, "Failed to return the correct status code");
         test:assertEquals(prevBundle2.'resource, testSearchDataSet1JsonUrlRewritten, "Failed to get the previous page bundle data");
@@ -438,22 +438,22 @@ function testPreviousBundle() returns FHIRError?|error {
 @test:Config {}
 function testBulkExportKickOff() returns FHIRError? {
     // System export kick off
-    FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
+    FHIRResponse result1 = check fhirConnector->/bulk/export(EXPORT_SYSTEM);
     test:assertEquals(result1.httpStatusCode, 202, "Failed to return the correct status code");
     test:assertTrue(result1.serverResponseHeaders["content-location"] != (), "Failed to return bulk export content location header");
 
     // Patient level export kick off
-    FHIRResponse result2 = check fhirConnector->bulkExport(EXPORT_PATIENT);
+    FHIRResponse result2 = check fhirConnector->/bulk/export(EXPORT_PATIENT);
     test:assertEquals(result2.httpStatusCode, 202, "Failed to return the correct status code");
     test:assertTrue(result2.serverResponseHeaders["content-location"] != (), "Failed to return bulk export content location header");
 
     // Export group kick off
-    FHIRResponse result3 = check fhirConnector->bulkExport(EXPORT_GROUP, "123");
+    FHIRResponse result3 = check fhirConnector->/bulk/export(EXPORT_GROUP, "123");
     test:assertEquals(result3.httpStatusCode, 202, "Failed to return the correct status code");
     test:assertTrue(result3.serverResponseHeaders["content-location"] != (), "Failed to return bulk export content location header");
 
     // Export group kick off with no group id
-    FHIRResponse|FHIRError result4 = fhirConnector->bulkExport(EXPORT_GROUP);
+    FHIRResponse|FHIRError result4 = fhirConnector->/bulk/export(EXPORT_GROUP);
     if result4 is FHIRError {
         if result4 is FHIRConnectorError {
             error? e = result4.detail().errorDetails;
@@ -469,7 +469,7 @@ function testBulkExportKickOff() returns FHIRError? {
     }
 
     // System export kick off with params
-    FHIRResponse result5 = check fhirConnector->bulkExport(
+    FHIRResponse result5 = check fhirConnector->/bulk/export(
         EXPORT_SYSTEM,
         bulkExportParameters = {
         _since: "2017-01-01T00:00:00Z",
@@ -483,20 +483,20 @@ function testBulkExportKickOff() returns FHIRError? {
 @test:Config {}
 function testBulkExportStatus() returns FHIRError? {
     // System export kick off
-    FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
+    FHIRResponse result1 = check fhirConnector->/bulk/export(EXPORT_SYSTEM);
     string pollingUrl = result1.serverResponseHeaders["content-location"] ?: "";
 
     // Polling the export status
-    FHIRResponse result2 = check fhirConnector->bulkStatus(pollingUrl);
+    FHIRResponse result2 = check fhirConnector->/bulk/status(pollingUrl);
     test:assertEquals(result2.httpStatusCode, 202, "Failed to return the correct status code");
 
     // Polling the export status when export is completed
-    FHIRResponse result3 = check fhirConnector->bulkStatus(string `${localhost}${testServerBaseUrl}/exportStatus/2`);
+    FHIRResponse result3 = check fhirConnector->/bulk/status(string `${localhost}${testServerBaseUrl}/exportStatus/2`);
     test:assertEquals(result3.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result3.'resource, testExportFileManifestData, "Failed to return the bulk export manifest");
 
     // Polling the export status when export is completed - url rewrite is enabled
-    FHIRResponse result4 = check urlRewriteConnector->bulkStatus(string `${replacementUrl}/exportStatus/2`);
+    FHIRResponse result4 = check urlRewriteConnector->/bulk/status(string `${replacementUrl}/exportStatus/2`);
     test:assertEquals(result4.httpStatusCode, 200, "Failed to return the correct status code");
     test:assertEquals(result4.'resource, testExportFileManifestDataUrlRewritten, "Failed to return the url rewritten bulk export manifest");
 
@@ -505,16 +505,16 @@ function testBulkExportStatus() returns FHIRError? {
 @test:Config {}
 function testBulkExportCancel() returns FHIRError? {
     // System export kick off
-    FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
+    FHIRResponse result1 = check fhirConnector->/bulk/export(EXPORT_SYSTEM);
     string pollingUrl = result1.serverResponseHeaders["content-location"] ?: "";
 
     // Cancel the export
-    FHIRResponse result2 = check fhirConnector->bulkDataDelete(pollingUrl);
+    FHIRResponse result2 = check fhirConnector->/bulk/export.delete(pollingUrl);
     test:assertEquals(result2.httpStatusCode, 202, "Failed to return the correct status code");
     test:assertEquals(result2.'resource, testBulkExportCancelResponse, "Failed to return the bulk export cancel success payload");
 
     // Using an invalid polling url
-    FHIRResponse|FHIRError result3 = fhirConnector->bulkDataDelete(string `${localhost}${testServerBaseUrl}/exportStatus/3`);
+    FHIRResponse|FHIRError result3 = fhirConnector->/bulk/export.delete(string `${localhost}${testServerBaseUrl}/exportStatus/3`);
     if result3 is FHIRError {
         if result3 is FHIRServerError {
             FHIRServerErrorDetails e = result3.detail();
@@ -532,11 +532,11 @@ function testBulkExportCancel() returns FHIRError? {
 @test:Config {}
 function testBulkExportFileAccess() returns error? {
     // Polling the export status when export is completed
-    FHIRResponse result1 = check urlRewriteConnector->bulkStatus(string `${replacementUrl}/exportStatus/2`);
+    FHIRResponse result1 = check urlRewriteConnector->/bulk/status(string `${replacementUrl}/exportStatus/2`);
     string fileUrl = (check (<json[]>(check (<json>result1.'resource).output))[0].url).toString();
 
     // Accessing the file
-    FHIRBulkFileResponse result2 = check urlRewriteConnector->bulkFile(fileUrl);
+    FHIRBulkFileResponse result2 = check urlRewriteConnector->/bulk/file(fileUrl);
     test:assertEquals(result2.httpStatusCode, 200, "Failed to return the correct status code");
 
     stream<byte[], io:Error?> fileStream = result2.dataStream;
@@ -554,7 +554,7 @@ function testBulkExportFileAccess() returns error? {
     test:assertEquals(fileContent, testBulkExportFileData, "Failed to return the correct file content");
 
     // With invalid url
-    FHIRBulkFileResponse|FHIRError result3 = urlRewriteConnector->bulkFile(fileUrl + "invalid");
+    FHIRBulkFileResponse|FHIRError result3 = urlRewriteConnector->/bulk/file(fileUrl + "invalid");
     if result3 is FHIRError {
         if result3 is FHIRServerError {
             FHIRServerErrorDetails e = result3.detail();


### PR DESCRIPTION
| Existing           | Changed to            | Sample usage                                                                |
|--------------------|-----------------------|-----------------------------------------------------------------------------|
|                    |                       |                                                                             |
| getById            | get /read/id          | fhirConnectorObj->/read/id(resType, id);                                    |
| getByVersion       | get /read/version     | fhirConnectorObj->/read/'version(resType, id = "123", 'version = 'version); |
| update             | put /fhirResource     | fhirConnectorObj->/fhirResource.put(resPayload);                            |
| patch              | patch /fhirResource   | fhirConnectorObj->/fhirResource.patch(resType, id, resPayload)              |
| delete             | delete /fhirResource  | fhirConnectorObj->/fhirResource.delete(resType, id);                        |
| getInstanceHistory | get /history/instance | fhirConnectorObj->/history/instance("Patient", "1234", {"_count": "10"});   |
| create             | post /fhirResource    | fhirConnectorObj->/fhirResource.post(resPayload);                           |
| search             | get /search/type      | fhirConnectorObj->/search/'type(resType, request.getQueryParams());         |
| getHistory         | get /history/type     | fhirConnectorObj->/history/'type("Patient", {_count: "10"});                |
| getConformance     | get /metadata         | fhirConnectorObj->/metadata();                                              |
| getAllHistory      | get /history          |                                                                             |
| searchAll          | get /search           |                                                                             |
| batchRequest       | post /batch           |                                                                             |
| transaction        | post /transaction     |                                                                             |
| nextBundle         | get /bundle/next      |                                                                             |