### PR TITLE
Implement POST Search and Custom Operations for Ballerina FHIR Client

### DIFF
--- a/fhir/Dependencies.toml
+++ b/fhir/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.10.2"
+distribution-version = "2201.12.2"
 
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.12.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.8.0"
+version = "3.10.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -33,7 +33,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.5.0"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.7.2"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -49,8 +49,17 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "data.jsondata"
+version = "1.1.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
 name = "file"
-version = "1.10.0"
+version = "1.12.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -61,12 +70,13 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.2"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -93,7 +103,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.6.1"
+version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -110,7 +120,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.13.0"
+version = "2.15.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -208,7 +218,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -222,7 +232,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.10.1"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -233,7 +243,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.12.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -246,7 +256,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.3.0"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -254,7 +264,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -263,10 +273,11 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.5.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"}
 ]
 
 [[package]]
@@ -286,7 +297,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.5.0"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -294,7 +305,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.4.0"
+version = "2.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -305,7 +316,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/fhir/constants.bal
+++ b/fhir/constants.bal
@@ -73,9 +73,9 @@ public enum BulkExportLevel {
 }
 
 public enum RequestMode {
-    GET = "GET",
-    POST = "POST"
-}
+    POST = "POST",
+    GET = "GET"
+};
 
 # Constant symbols
 const AMPERSAND = "&";
@@ -84,6 +84,8 @@ const QUOTATION_MARK = "\"";
 const QUESTION_MARK = "?";
 const EQUALS_SIGN = "=";
 const COMMA = ",";
+const DOLLAR_SIGN = "$";
+const ENCODED_DOLLAR_SIGN = "%24";
 
 # FHIR  parameters 
 const _FORMAT = "_format";

--- a/fhir/constants.bal
+++ b/fhir/constants.bal
@@ -72,6 +72,11 @@ public enum BulkExportLevel {
     EXPORT_GROUP = "Group"
 }
 
+public enum RequestMode {
+    GET = "GET",
+    POST = "POST"
+}
+
 # Constant symbols
 const AMPERSAND = "&";
 const SLASH = "/";
@@ -87,8 +92,14 @@ const _HISTORY = "_history";
 const METADATA = "metadata";
 const MODE = "mode";
 
+# Resource paths
+const _SEARCH = "_search";
+
 # Bulk export
 const EXPORT = "$export";
+
+# x-www-form-urlencoded content type
+const APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
 
 # Server Status codes
 const STATUS_CODE_OK = 200;
@@ -116,6 +127,7 @@ const PAYLOAD_CONSTRUCTION_ERROR = "Error occurred when constructing the respons
 const MISSING_RES_TYPE = "Resource type not found";
 const REPLACEMENT_URL_NOT_PROVIDED = "URL rewrite is set to true, but replacement URL is not provided";
 const GROUP_ID_NOT_PROVIDED = "The parameter 'groupId' is not provided for Group Bulk Export operation";
+const INTERNATIONAL_401_NOT_SUPPORTED = "International401 parameters are not supported for GET requests";
 
 # XML attributes
 const XML_ID = "id";

--- a/fhir/fhir_connector.bal
+++ b/fhir/fhir_connector.bal
@@ -16,6 +16,7 @@
 
 import ballerina/http;
 import ballerinax/health.base.auth;
+import ballerina/log;
 
 # This connector allows you to connect and interact with any FHIR server
 @display {label: "FHIR Client Connector"}
@@ -309,17 +310,17 @@ public isolated client class FHIRConnector {
             @display {label: "Search Parameters"} SearchParameters|map<string[]>? searchParameters = (),
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
                                     returns FHIRResponse|FHIRError {
-        string requestUrl = SLASH + 'type;
+        string requestUrl;
         map<string> headerMap = {[ACCEPT_HEADER] : self.mimeType};
         do {
             http:Response response;
             
             if mode == GET {
-                requestUrl += setSearchParams(searchParameters, returnMimeType);
+                requestUrl = string `${SLASH}${'type}${setSearchParams(searchParameters, returnMimeType)}`;
 
                 response = check self.httpClient->get(requestUrl, check enrichHeaders(headerMap, self.pkjwtHanlder));
             } else {
-                requestUrl += SLASH + _SEARCH + setSearchParams((), returnMimeType);
+                requestUrl = string `${SLASH}${'type}${SLASH}${_SEARCH}${setSearchParams((), returnMimeType)}`;
 
                 http:Request req = new;
                 req.setTextPayload(createSearchFormData(searchParameters), contentType = APPLICATION_X_WWW_FORM_URLENCODED);
@@ -333,6 +334,7 @@ public isolated client class FHIRConnector {
             }
             return result;
         } on fail error e {
+            log:printError(string `${FHIR_CONNECTOR_ERROR}: ${e.message()}`,  e);
             if e is FHIRError {
                 return e;
             }
@@ -440,10 +442,10 @@ public isolated client class FHIRConnector {
         do {
             http:Response response;
             if mode == GET {
-                requestUrl = QUESTION_MARK + setSearchParams(searchParameters, returnMimeType);
+                requestUrl = string `${QUESTION_MARK}${setSearchParams(searchParameters, returnMimeType)}`;
                 response = check self.httpClient->get(requestUrl, check enrichHeaders(headerMap, self.pkjwtHanlder));
             } else {
-                requestUrl = SLASH + _SEARCH + setSearchParams((), returnMimeType);
+                requestUrl = string `${SLASH}${_SEARCH}${setSearchParams((), returnMimeType)}`;
 
                 http:Request req = new;
                 req.setTextPayload(createSearchFormData(searchParameters), contentType = APPLICATION_X_WWW_FORM_URLENCODED);
@@ -456,6 +458,7 @@ public isolated client class FHIRConnector {
             }
             return result;
         } on fail error e {
+            log:printError(string `${FHIR_CONNECTOR_ERROR}: ${e.message()}`,  e);
             if e is FHIRError {
                 return e;
             }
@@ -728,7 +731,7 @@ public isolated client class FHIRConnector {
             @display {label: "Resource data"} json|xml? data = (),
             @display {label: "Return MIME Type"} MimeType? returnMimeType = ())
                                     returns FHIRResponse|FHIRError {
-        string requestUrl = SLASH + 'type + setOperationName(operationName, id) + setCallOperationParams(queryParameters, returnMimeType);
+        string requestUrl = string `${SLASH}${'type}${setOperationName(operationName, id)}${setCallOperationParams(queryParameters, returnMimeType)}`;
         map<string> headerMap = {[ACCEPT_HEADER] : self.mimeType};
         do {
             http:Response response;
@@ -748,6 +751,7 @@ public isolated client class FHIRConnector {
             }
             return result;
         } on fail error e {
+            log:printError(string `${FHIR_CONNECTOR_ERROR}: ${e.message()}`,  e);
             if e is FHIRError {
                 return e;
             }

--- a/fhir/utils.bal
+++ b/fhir/utils.bal
@@ -213,7 +213,7 @@ isolated function getBundleResponse(http:Response response) returns FHIRResponse
 }
 
 isolated function setSearchParams(SearchParameters|map<string[]>? qparams, MimeType? returnMimeType) returns string {
-    string url = "";
+    string url = QUESTION_MARK;
     if (qparams is SearchParameters) {
         foreach string key in qparams.keys() {
             if (qparams.get(key) is string[]) {
@@ -235,7 +235,32 @@ isolated function setSearchParams(SearchParameters|map<string[]>? qparams, MimeT
         }
     }
     url += setFormatParameters(returnMimeType);
-    return url.endsWith("&") ? url.substring(0, url.length() - 1) : url;
+    return url.endsWith(AMPERSAND) || url.endsWith(QUESTION_MARK) ? url.substring(0, url.length() - 1) : url;
+}
+
+isolated function createSearchFormData(SearchParameters|map<string[]>? qparams) returns string {
+    string formData = "";
+    if (qparams is SearchParameters) {
+        foreach string key in qparams.keys() {
+            if (qparams.get(key) is string[]) {
+                string[] params = <string[]>qparams.get(key);
+                foreach string param in params {
+                    formData += key + EQUALS_SIGN + param + AMPERSAND;
+                }
+            } else {
+                string val = <string>qparams.get(key);
+                formData += key + EQUALS_SIGN + val + AMPERSAND;
+            }
+        }
+    }
+    if (qparams is map<string[]>) {
+        foreach string key in qparams.keys() {
+            foreach string param in qparams.get(key) {
+                formData += key + EQUALS_SIGN + param + AMPERSAND;
+            }
+        }
+    }
+    return formData.endsWith(AMPERSAND) ? formData.substring(0, formData.length() - 1) : formData;
 }
 
 isolated function setCapabilityParams(map<anydata>? params, MimeType? returnMimeType) returns string {

--- a/fhir/utils.bal
+++ b/fhir/utils.bal
@@ -28,6 +28,9 @@ isolated function setFormatNSummaryParameters(MimeType? mimeType, SummaryType? s
     return paramString;
 }
 
+isolated function setOperationName(string operationName, string? id) returns string =>
+    SLASH + (id is string ? id + SLASH : "") + (operationName.startsWith(DOLLAR_SIGN) || operationName.startsWith(ENCODED_DOLLAR_SIGN) ? operationName : DOLLAR_SIGN + operationName);
+
 isolated function setFormatParameters(MimeType? mimeType) returns string =>
     mimeType is () ? "" : string `${_FORMAT}${EQUALS_SIGN}${mimeType}`;
 
@@ -261,6 +264,19 @@ isolated function createSearchFormData(SearchParameters|map<string[]>? qparams) 
         }
     }
     return formData.endsWith(AMPERSAND) ? formData.substring(0, formData.length() - 1) : formData;
+}
+
+isolated function setCallOperationParams(map<string[]>? qparams, MimeType? returnMimeType) returns string {
+    string url = QUESTION_MARK;
+    if (qparams is map<string[]>) {
+        foreach string key in qparams.keys() {
+            foreach string param in qparams.get(key) {
+                url += key + EQUALS_SIGN + param + AMPERSAND;
+            }
+        }
+    }
+    url += setFormatParameters(returnMimeType);
+    return url.endsWith(AMPERSAND) || url.endsWith(QUESTION_MARK) ? url.substring(0, url.length() - 1) : url;
 }
 
 isolated function setCapabilityParams(map<anydata>? params, MimeType? returnMimeType) returns string {

--- a/fhir/utils.bal
+++ b/fhir/utils.bal
@@ -29,7 +29,7 @@ isolated function setFormatNSummaryParameters(MimeType? mimeType, SummaryType? s
 }
 
 isolated function setOperationName(string operationName, string? id) returns string =>
-    SLASH + (id is string ? id + SLASH : "") + (operationName.startsWith(DOLLAR_SIGN) || operationName.startsWith(ENCODED_DOLLAR_SIGN) ? operationName : DOLLAR_SIGN + operationName);
+    SLASH + (id is string ? id + SLASH : "") + (operationName.startsWith(DOLLAR_SIGN) || operationName.startsWith(ENCODED_DOLLAR_SIGN) ? operationName : ENCODED_DOLLAR_SIGN + operationName);
 
 isolated function setFormatParameters(MimeType? mimeType) returns string =>
     mimeType is () ? "" : string `${_FORMAT}${EQUALS_SIGN}${mimeType}`;


### PR DESCRIPTION
## Purpose
This PR introduces enhancements to the Ballerina FHIR Client to support POST search and custom operations, addressing key limitations and expanding functionality.

Resolve:
- https://github.com/ballerina-platform/ballerina-library/issues/7968
- https://github.com/ballerina-platform/ballerina-library/issues/7969

## Goals

- Add POST search interaction to the Ballerina FHIR Client.
- Add ability to construct custom interactions

## Approach
- Implemented a `RequestMode` enum with values `POST` and `GET` to specify the HTTP method for requests.
- Refactored `search()` and `searchAll()` functions to accept `RequestMode` and enable POST search.
- Added a new `callOperation()` function to invoke custom FHIR operations like `$lookup` and `$validate-code`, supporting both GET and POST requests.
- Included example usage demonstrating both POST search and custom operation invocation.

This enhances the FHIR Client's capabilities, allowing more complex and versatile interactions with FHIR servers.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   - 76% of code coverage
 - Integration tests
   - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
- Refactored `search()` function
  `FHIRResponse result2 = check fhirConnector->search(PATIENT);`
  `FHIRResponse result3 = check fhirConnector->search(PATIENT, mode = POST);`

- `callOperation()` function
  `FHIRResponse|FHIRError response = fhirConnector->callOperation('type = r4:RESOURCE_NAME_CODESYSTEM, operationName = "$lookup", queryParameters = {"code": ["2133-7"], "system": ["urn:oid:2.16.840.1.113883.6.238"]});`


## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- JDK: openjdk 21.0.6
- Ballerina: 2201.12.2
- OS: Windows 11
 
## Learning
N/A