### PR TITLE
Add CapabilityStatement validation to FHIRConnector initialization to verify FHIR service compliance

### DIFF
--- a/.github/workflows/build-executor.yml
+++ b/.github/workflows/build-executor.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
 env:
-  BALLERINA_VERSION: 2201.10.2
+  BALLERINA_VERSION: 2201.12.3
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   FHIR_PATTERN: '*/*'
   GITHUB_WORKFLOWS_DIR: '.github'
-  BALLERINA_VERSION: 2201.10.2
+  BALLERINA_VERSION: 2201.12.3
 
 jobs:
   setup:

--- a/.github/workflows/daily-build-executor.yml
+++ b/.github/workflows/daily-build-executor.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 env:
-  BALLERINA_VERSION: 2201.10.2
+  BALLERINA_VERSION: 2201.12.3
 
 jobs:
   build:

--- a/fhir/Ballerina.toml
+++ b/fhir/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "health.clients.fhir"
-version = "2.1.1"
+version = "3.0.0"
 distribution = "2201.12.3"
 authors=["Ballerina"]
 keywords=["Healthcare", "FHIR", "client", "R4"]

--- a/fhir/Dependencies.toml
+++ b/fhir/Dependencies.toml
@@ -351,7 +351,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.base"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},

--- a/fhir/Dependencies.toml
+++ b/fhir/Dependencies.toml
@@ -371,7 +371,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.clients.fhir"
-version = "2.1.1"
+version = "3.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},

--- a/fhir/README.md
+++ b/fhir/README.md
@@ -1,4 +1,3 @@
-
 # Ballerina FHIR Client Connector
 
 A generic FHIR client module for Ballerina, enabling seamless integration with FHIR servers for healthcare applications. This connector supports all standard FHIR operations, including CRUD, conditional interactions, and bulk data export, with support for various authentication mechanisms.
@@ -238,6 +237,12 @@ fhir_client:FHIRResponse|fhir_client:FHIRError response =
     fhir_client:FHIRResponse|fhir_client:FHIRError response =
         fhirConnector->bulkDataDelete("<content-location-url>");
     ```
+
+### CapabilityStatement Validation
+
+> **Note:** This validation is available in `ballerinax/health.clients.fhir` version 3.0.0 onwards.
+
+When initializing the `FHIRConnector`, the connector automatically retrieves and validates the FHIR server's [CapabilityStatement](https://hl7.org/fhir/capabilitystatement.html) as part of its `init` function. This validation ensures that the target service is a genuine FHIR server and supports the required FHIR version (such as R4 or R5). If the CapabilityStatement is missing, invalid, or indicates an unsupported FHIR version, the connector initialization will fail. This mechanism is essential for verifying that the service you are connecting to is a compliant FHIR service before performing any operations.
 
 ## Advanced Features
 

--- a/fhir/tests/test.bal
+++ b/fhir/tests/test.bal
@@ -27,7 +27,7 @@ FHIRConnectorConfig config = {
     baseURL: localhost + testServerBaseUrl,
     mimeType: FHIR_JSON
 };
-FHIRConnector fhirConnector = check new (config);
+FHIRConnector fhirConnector;
 
 FHIRConnectorConfig urlRewriteConfig = {
     baseURL: localhost + testServerBaseUrl,
@@ -35,16 +35,17 @@ FHIRConnectorConfig urlRewriteConfig = {
     urlRewrite: true,
     replacementURL: replacementUrl
 };
-FHIRConnector urlRewriteConnector = check new (urlRewriteConfig);
+FHIRConnector urlRewriteConnector;
 
 listener http:Listener listenerEP = check new (8080);
 
-@test:BeforeSuite
-function setup() returns error? {
+function init() returns error? {
     check listenerEP.attach(FhirMockService, testServerBaseUrl);
     check listenerEP.'start();
     log:printInfo("FHIR mock service has started");
 
+    fhirConnector = check new (config);
+    urlRewriteConnector = check new (urlRewriteConfig);
 }
 
 @test:Config {}

--- a/fhir/utils.bal
+++ b/fhir/utils.bal
@@ -663,3 +663,9 @@ isolated function matchesQueryPattern(string input) returns boolean {
     string pattern = "^[^=&?]+=[^=&]+(?:&[^=&?]+=[^=&]+)*$";
     return regex:matches(input, pattern);
 }
+
+function isSupportedFhirVersion(string fhirVersion) returns boolean {
+    // Accepts FHIR versions R4 (4.x.x) and onwards (e.g., 4.0.1, 5.0.0)
+    string versionPattern = "^(4|5)\\.[0-9]+\\.[0-9]+$";
+    return regex:matches(fhirVersion, versionPattern);
+}


### PR DESCRIPTION
## Purpose
Introduce automatic validation of the FHIR server’s `CapabilityStatement` during the initialization of the `FHIRConnector`.
Resolve: 
- https://github.com/wso2-enterprise/open-healthcare/issues/1760

## Goals
Ensure that the FHIR client only connects to genuine and supported FHIR servers by verifying the presence and validity of the `CapabilityStatement`, including supported FHIR version checks (e.g., R4, R5). This prevents accidental connections to non-compliant or incompatible services.

## Approach

- During the init function of the FHIRConnector, retrieve the server’s CapabilityStatement.
- Validate that the CapabilityStatement exists and contains a supported FHIR version.
- Fail initialization with a clear error if the server is not a valid or supported FHIR service.

## User stories
N/A

## Release note
This is a major release for the FHIR client. 

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   Code Coverage: 74.74%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment

- JDK: openjdk 21.0.6
- Ballerina: 2201.12.3
- OS: Windows 11

 
## Learning
N/A