### PR TITLE
Add Asynchronous Bulk Export Support with In-Memory Task Tracking to FHIR Client

### DIFF
--- a/fhir/Dependencies.toml
+++ b/fhir/Dependencies.toml
@@ -66,6 +66,23 @@ dependencies = [
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "time"}
 ]
+modules = [
+	{org = "ballerina", packageName = "file", moduleName = "file"}
+]
+
+[[package]]
+org = "ballerina"
+name = "ftp"
+version = "2.13.1"
+dependencies = [
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "task"}
+]
+modules = [
+	{org = "ballerina", packageName = "ftp", moduleName = "ftp"}
+]
 
 [[package]]
 org = "ballerina"
@@ -291,6 +308,9 @@ dependencies = [
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "uuid"}
 ]
+modules = [
+	{org = "ballerina", packageName = "task", moduleName = "task"}
+]
 
 [[package]]
 org = "ballerina"
@@ -313,6 +333,9 @@ version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "time", moduleName = "time"}
+]
 
 [[package]]
 org = "ballerina"
@@ -334,6 +357,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "uuid", moduleName = "uuid"}
 ]
 
 [[package]]
@@ -373,12 +399,17 @@ org = "ballerinax"
 name = "health.clients.fhir"
 version = "2.1.1"
 dependencies = [
+	{org = "ballerina", name = "file"},
+	{org = "ballerina", name = "ftp"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "task"},
 	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "url"},
+	{org = "ballerina", name = "uuid"},
 	{org = "ballerinai", name = "observe"},
 	{org = "ballerinax", name = "health.base"}
 ]

--- a/fhir/Dependencies.toml
+++ b/fhir/Dependencies.toml
@@ -214,6 +214,9 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
 
 [[package]]
 org = "ballerina"
@@ -255,6 +258,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "log"}
+]
+modules = [
+	{org = "ballerina", packageName = "mime", moduleName = "mime"}
 ]
 
 [[package]]
@@ -377,7 +383,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.base"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
@@ -403,7 +409,9 @@ dependencies = [
 	{org = "ballerina", name = "ftp"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "mime"},
 	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "task"},
 	{org = "ballerina", name = "test"},

--- a/fhir/bulk_export_utils.bal
+++ b/fhir/bulk_export_utils.bal
@@ -1,0 +1,212 @@
+// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/file;
+import ballerina/ftp;
+import ballerina/http;
+import ballerina/io;
+import ballerina/log;
+import ballerina/task;
+
+isolated function executeJob(PollingTask job, decimal interval) returns task:JobId|error? {
+    task:JobId id = check task:scheduleJobRecurByFrequency(job, interval);
+    job.setId(id);
+    return id;
+}
+
+function unscheduleJob(task:JobId id) returns error? {
+    log:printDebug("Unscheduling the job.", Jobid = id);
+    task:Error? unscheduleJob = task:unscheduleJob(id);
+    if unscheduleJob is task:Error {
+        log:printError("Error occurred while unscheduling the job.", unscheduleJob);
+    }
+    return null;
+}
+
+function getFileAsStream(string downloadLink, http:Client statusClientV2) returns stream<byte[], io:Error?>|error? {
+    http:Response|http:ClientError statusResponse = statusClientV2->get("/");
+    if statusResponse is http:Response {
+        int status = statusResponse.statusCode;
+        if status == 200 {
+            return check statusResponse.getByteStream();
+        } else {
+            log:printError("Error occurred while getting the status.");
+        }
+    } else {
+        log:printError("Error occurred while getting the status.", statusResponse);
+    }
+    return null;
+}
+
+function saveFileInFS(string downloadLink, string fileName) returns error? {
+    http:Client statusClientV2 = check new (downloadLink);
+    stream<byte[], io:Error?> streamer = check getFileAsStream(downloadLink, statusClientV2) ?: new ();
+    check io:fileWriteBlocksFromStream(fileName, streamer);
+    check streamer.close();
+    log:printDebug(string `Successfully downloaded the file. File name: ${fileName}`);
+}
+
+function sendFileFromFSToFTP(TargetServerConfig config, string sourcePath, string fileName) returns error? {
+    // Implement the FTP server logic here.
+    ftp:Client fileClient = check new ({
+        host: config.host,
+        auth: {
+            credentials: {
+                username: config.username,
+                password: config.password
+            }
+        }
+    });
+    stream<io:Block, io:Error?> fileStream
+        = check io:fileReadBlocksAsStream(sourcePath, 1024);
+    check fileClient->put(string `${config.directory}/${fileName}`, fileStream);
+    check fileStream.close();
+}
+
+function downloadFiles(json exportSummary, string exportId, string targetDirectory, TargetServerConfig targetServerConfig) returns error? {
+    ExportSummary exportSummary1 = check exportSummary.cloneWithType(ExportSummary);
+    foreach OutputFile item in exportSummary1.output {
+        log:printDebug("Downloading the file.", url = item.url);
+        error? downloadFileResult = saveFileInFS(item.url, string `${targetDirectory}${file:pathSeparator}${exportId}${file:pathSeparator}${item.'type}-exported.ndjson`);
+        if downloadFileResult is error {
+            log:printError("Error occurred while downloading the file.", downloadFileResult);
+        }
+
+        if targetServerConfig.'type == "ftp" {
+            // download the file to the FTP server
+            // implement the FTP server logic
+            error? uploadFileResult = sendFileFromFSToFTP(targetServerConfig, string `${targetDirectory}${file:pathSeparator}${item.'type}-exported.ndjson`, string `${item.'type}-exported.ndjson`);
+            if uploadFileResult is error {
+                log:printError("Error occurred while sending the file to ftp.", downloadFileResult);
+
+            }
+        }
+    }
+    lock {
+        boolean _ = updateExportTaskStatusInMemory(taskMap = exportTasks, exportTaskId = exportId, newStatus = "Downloaded");
+    }
+    log:printInfo("All files downloaded successfully.");
+    return null;
+}
+
+function addQueryParam(string queryString, string key, string value) returns string {
+    if queryString == "" {
+        return string `?${key}=${value}`;
+    } else {
+        return string `${queryString}&${key}=${value}`;
+    }
+}
+
+class PollingTask {
+    *task:Job;
+    string exportId;
+    string lastStatus;
+    string location;
+    string targetDirectory;
+    TargetServerConfig? targetServerConfig;
+    task:JobId jobId = {id: 0};
+
+    public function execute() {
+        do {
+            http:Client statusClientV2 = check new (self.location);
+            log:printDebug("Polling the export task status.", exportId = self.exportId);
+            if self.lastStatus == "In-progress" {
+                http:Response|http:ClientError statusResponse;
+                statusResponse = statusClientV2->/;
+                addPollingEvent addPollingEventFuntion = addPollingEventToMemory;
+                if statusResponse is http:Response {
+                    int status = statusResponse.statusCode;
+                    if status == 200 {
+                        self.setLastStaus("Completed");
+                        lock {
+                            boolean _ = updateExportTaskStatusInMemory(taskMap = exportTasks, exportTaskId = self.exportId, newStatus = "Export Completed. Downloading files.");
+                        }
+                        json payload = check statusResponse.getJsonPayload();
+                        log:printDebug("Export task completed.", exportId = self.exportId, payload = payload);
+                        error? unscheduleJobResult = unscheduleJob(self.jobId);
+                        if unscheduleJobResult is error {
+                            log:printError("Error occurred while unscheduling the job.", unscheduleJobResult);
+                        }
+
+                        // download the files
+                        if self.targetServerConfig is TargetServerConfig {
+                            error? downloadFilesResult = downloadFiles(payload, self.exportId, self.targetDirectory, <TargetServerConfig>self.targetServerConfig);
+                            if downloadFilesResult is error {
+                                log:printError("Error in downloading files", downloadFilesResult);
+                            }
+                        }
+                    } else if status == 202 {
+                        log:printDebug("Export task in-progress.", exportId = self.exportId);
+                        string progress = check statusResponse.getHeader("X-Progress");
+                        PollingEvent pollingEvent = {id: self.exportId, eventStatus: "Success", exportStatus: progress};
+                        lock {
+                            boolean _ = addPollingEventFuntion(exportTasks, pollingEvent.clone());
+                        }
+                        self.setLastStaus("In-progress");
+                    }
+                } else {
+                    log:printError("Error occurred while getting the status.", statusResponse);
+                    lock {
+                        PollingEvent pollingEvent = {id: self.exportId, eventStatus: "Failed"};
+                        boolean _ = addPollingEventFuntion(exportTasks, pollingEvent.cloneReadOnly());
+                    }
+                }
+            } else if self.lastStatus == "Completed" {
+                log:printDebug("Export task completed.", exportId = self.exportId);
+            }
+        } on fail var e {
+            log:printError("Error occurred while polling the export task status.", e);
+        }
+    }
+
+    isolated function init(string exportId, string location, string directory, string lastStatus = "In-progress", TargetServerConfig? config = ()) {
+        self.exportId = exportId;
+        self.lastStatus = lastStatus;
+        self.location = location;
+        self.targetDirectory = directory;
+        self.targetServerConfig = config;
+    }
+
+    function setLastStaus(string newStatus) {
+        self.lastStatus = newStatus;
+    }
+
+    isolated function setId(task:JobId jobId) {
+        self.jobId = jobId;
+    }
+}
+
+isolated function submitBackgroundJob(string taskId, http:Response|http:ClientError status, decimal defaultIntervalInSec, string targetDirectory, TargetServerConfig? targetServerConfig) {
+    if status is http:Response {
+        // get the location of the status check
+        do {
+            string location = check status.getHeader(CONTENT_LOCATION);
+            task:JobId|() _ = check executeJob(
+                    new PollingTask(
+                        exportId = taskId,
+                        location = location,
+                        directory = targetDirectory,
+                        config = targetServerConfig
+                    ),
+                    defaultIntervalInSec);
+            log:printDebug("Polling location recieved: " + location);
+        } on fail var e {
+            log:printError("Error occurred while getting the location or scheduling the Job", e);
+        }
+    } else {
+        log:printError("Error occurred while sending the kick-off request to the bulk export server.", status);
+    }
+}

--- a/fhir/constants.bal
+++ b/fhir/constants.bal
@@ -260,6 +260,8 @@ const LOCATION = "Location";
 const CONTENT_TYPE = "Content-Type";
 const CONTENT_LOCATION = "Content-Location";
 const IF_NONE_EXISTS = "If-None-Exist";
+const X_PROGRESS = "X-Progress";
+const EXPORT_ID = "Export-ID";
 
 # Error messages 
 const RESOURCE_ID_NOT_FOUND_IN_DATA = "The provided resource data doesn't contain a id value";
@@ -276,6 +278,8 @@ const REPLACEMENT_URL_NOT_PROVIDED = "URL rewrite is set to true, but replacemen
 const GROUP_ID_NOT_PROVIDED = "The parameter 'groupId' is not provided for Group Bulk Export operation";
 const MISSING_ID = "'id' is a mandatory parameter for the interaction";
 const INVALID_CONDITIONAL_URL = "The provided conditional URL is invalid";
+const BULK_EXPORT_ID_NOT_PROVIDED = "Either exportId or contentLocation must be provided for the Bulk Export Status operation";
+const BULK_FILE_URL_NOT_PROVIDED = "Either fileUrl or exportId must be provided for the Bulk Export File operation";
 
 # XML attributes
 const XML_ID = "id";
@@ -292,4 +296,4 @@ const SELF = "self";
 
 # default values
 const DEFAULT_POLLING_INTERVAL = 2.0d;
-const DEFAULT_EXPORT_DIRECTORY = "/export_directory";
+const DEFAULT_EXPORT_DIRECTORY = "bulk_export";

--- a/fhir/constants.bal
+++ b/fhir/constants.bal
@@ -280,6 +280,7 @@ const MISSING_ID = "'id' is a mandatory parameter for the interaction";
 const INVALID_CONDITIONAL_URL = "The provided conditional URL is invalid";
 const BULK_EXPORT_ID_NOT_PROVIDED = "Either exportId or contentLocation must be provided for the Bulk Export Status operation";
 const BULK_FILE_URL_NOT_PROVIDED = "Either fileUrl or exportId must be provided for the Bulk Export File operation";
+const BULK_FILE_SERVER_CONFIG_NOT_PROVIDED = "The target server configuration is not provided for the Bulk Export File operation";
 
 # XML attributes
 const XML_ID = "id";

--- a/fhir/constants.bal
+++ b/fhir/constants.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -290,3 +290,6 @@ const PREVIOUS = "previous";
 const PREV = "prev";
 const SELF = "self";
 
+# default values
+const DEFAULT_POLLING_INTERVAL = 2.0d;
+const DEFAULT_EXPORT_DIRECTORY = "/export_directory";

--- a/fhir/in_memory_storage.bal
+++ b/fhir/in_memory_storage.bal
@@ -1,0 +1,61 @@
+// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/time;
+
+//This file represents the in-memory storage of the export tasks and polling events.
+
+final isolated map<ExportTask> exportTasks = {};
+
+isolated function addExportTasktoMemory(map<ExportTask> taskMap, ExportTask exportTask) returns boolean {
+    // add the export task to the memory
+    exportTask.lastUpdated = time:utcNow();
+    lock {
+        taskMap[exportTask.id] = exportTask;
+    }
+    return true;
+}
+
+isolated function addPollingEventToMemory(map<ExportTask> taskMap, PollingEvent pollingEvent) returns boolean {
+    // add the polling event to the memory
+    ExportTask exportTask = taskMap.get(pollingEvent.id);
+    exportTask.lastUpdated = time:utcNow();
+    exportTask.lastStatus = pollingEvent.exportStatus ?: "In-progress";
+    lock {
+        taskMap.get(pollingEvent.id).pollingEvents.push(pollingEvent);
+    }
+    return true;
+}
+
+isolated function updateExportTaskStatusInMemory(map<ExportTask> taskMap, string exportTaskId, string newStatus) returns boolean {
+    ExportTask exportTask = taskMap.get(exportTaskId);
+    exportTask.lastUpdated = time:utcNow();
+    exportTask.lastStatus = newStatus;
+    return true;
+}
+
+isolated function getExportTaskFromMemory(string exportId) returns ExportTask|error {
+    // get the export task from the memory
+    ExportTask? exportTask;
+    lock {
+        exportTask = exportTasks.get(exportId).clone();
+    }
+    if exportTask is ExportTask {
+        return exportTask.clone();
+    } else {
+        return error("ExportTask not found for exportId: " + exportId);
+    }
+}

--- a/fhir/records.bal
+++ b/fhir/records.bal
@@ -91,33 +91,27 @@ public type FHIRConnectorConfig record {|
 #
 # + fileServerUrl - Bulk export file server base url
 # + defaultIntervalInSec - Default interval in seconds for the bulk export server to poll the file server for new files
-# + temporaryDirectory - temporary directory to save the exported files
-# + targetServerConfig - Target server config to upload the files to a remote server (e.g., FTP server)
+# + 'type - FHIR or FTP  
+# + host - host name of the server
+# + username - user name to access the server, for ftp
+# + password - password to access the server, for ftp
+# + directory - directory to save the exported files
 public type BulkFileServerConfig record {|
     *http:ClientConfiguration;
     @display {label: "Bulk export file server base url"}
     string? fileServerUrl = ();
     @display {label: "Bulk export server interval in seconds"}
     decimal? defaultIntervalInSec = ();
-    @display {label: "Bulk export target directory"}
-    string? temporaryDirectory = ();
-    @display {label: "Bulk export target server config"}
-    TargetServerConfig? targetServerConfig;
-|};
-
-# Server config for import FHIR resources.
-#
-# + 'type - FHIR or FTP  
-# + host - host name of the server
-# + username - user name to access the server, for ftp
-# + password - password to access the server, for ftp
-# + directory - directory to save the exported files
-public type TargetServerConfig record {|
-    "fhir"|"ftp" 'type;
+    @display {label: "File server host url"}
     string host;
+    @display {label: "File server username"}
     string username;
+    @display {label: "File server password"}
     string password;
+    @display {label: "Directory to save exported files"}
     string directory;
+    @display {label: "File server type"}
+    "fhir"|"ftp" 'type;
 |};
 
 # Represents a success response coming from the fhir server side

--- a/fhir/records.bal
+++ b/fhir/records.bal
@@ -16,8 +16,8 @@
 
 import ballerina/http;
 import ballerina/io;
-import ballerinax/health.base.auth;
 import ballerina/time;
+import ballerinax/health.base.auth;
 
 # Represents FHIR client connector configurations
 #
@@ -91,16 +91,16 @@ public type FHIRConnectorConfig record {|
 #
 # + fileServerUrl - Bulk export file server base url
 # + defaultIntervalInSec - Default interval in seconds for the bulk export server to poll the file server for new files
-# + targetDirectory - Target directory where the bulk export files will be stored
+# + temporaryDirectory - temporary directory to save the exported files
 # + targetServerConfig - Target server config to upload the files to a remote server (e.g., FTP server)
 public type BulkFileServerConfig record {|
     *http:ClientConfiguration;
     @display {label: "Bulk export file server base url"}
-    string fileServerUrl;
+    string? fileServerUrl = ();
     @display {label: "Bulk export server interval in seconds"}
-    decimal defaultIntervalInSec;
+    decimal? defaultIntervalInSec = ();
     @display {label: "Bulk export target directory"}
-    string targetDirectory;
+    string? temporaryDirectory = ();
     @display {label: "Bulk export target server config"}
     TargetServerConfig? targetServerConfig;
 |};
@@ -109,14 +109,12 @@ public type BulkFileServerConfig record {|
 #
 # + 'type - FHIR or FTP  
 # + host - host name of the server
-# + port - port number of the server
 # + username - user name to access the server, for ftp
 # + password - password to access the server, for ftp
 # + directory - directory to save the exported files
 public type TargetServerConfig record {|
-    string 'type;
+    "fhir"|"ftp" 'type;
     string host;
-    int port;
     string username;
     string password;
     string directory;
@@ -131,7 +129,6 @@ public type FHIRResponse record {|
     int httpStatusCode;
     json|xml 'resource;
     map<string> serverResponseHeaders;
-
 |};
 
 # Represents a bulk file response coming from the fhir server side
@@ -154,7 +151,6 @@ public type FHIRServerErrorDetails record {|
     int httpStatusCode;
     json|xml 'resource;
     map<string> serverResponseHeaders;
-
 |};
 
 # Represents the error type for an unsuccessful interaction with the server 
@@ -278,11 +274,11 @@ type Pagination record {|
 |};
 
 // record to map exported resource metadata.
-type OutputFile record {|
+type OutputFile record {
     string 'type;
     string url;
     int count;
-|};
+};
 
 // record to hold summary of exports.
 type ExportSummary record {
@@ -309,15 +305,3 @@ type ExportTask record {|
     string lastStatus;
     PollingEvent[] pollingEvents;
 |};
-
-// Function types to interact with the storage impl.
-
-type getExportTask function (string exportId) returns ExportTask;
-
-type getPollingEvents function (string exportId) returns [PollingEvent];
-
-type addExportTask isolated function (map<ExportTask> taskMap, ExportTask exportTask) returns boolean;
-
-type addPollingEvent isolated function (map<ExportTask> taskMap, PollingEvent pollingEvent) returns boolean;
-
-type updateExportTaskStatus function (map<ExportTask> taskMap, string exportTaskId, string newStatus) returns boolean;

--- a/fhir/tests/Config.toml
+++ b/fhir/tests/Config.toml
@@ -1,0 +1,2 @@
+[ballerina.log]
+level = "DEBUG"

--- a/fhir/tests/Config.toml
+++ b/fhir/tests/Config.toml
@@ -1,2 +1,0 @@
-[ballerina.log]
-level = "DEBUG"

--- a/fhir/tests/mock_service.bal
+++ b/fhir/tests/mock_service.bal
@@ -64,6 +64,8 @@ http:Service FhirMockService = service object {
         } else if 'type == PATIENT && id == EXPORT {
             response.statusCode = http:STATUS_ACCEPTED;
             response.setHeader(CONTENT_LOCATION, string `${localhost}${testServerBaseUrl}/exportStatus/1`);
+            response.setHeader(CONTENT_TYPE, FHIR_JSON);
+            response.setPayload({ "status": "in-progress" }, FHIR_JSON);
             return response;
         } else {
             response.statusCode = http:STATUS_NOT_FOUND;
@@ -249,9 +251,11 @@ http:Service FhirMockService = service object {
     resource function get [string 'type](string? offset, string? _format) returns http:Response {
         http:Response response = new ();
 
-        if ('type == "$export") {
+        if 'type == EXPORT {
             response.statusCode = http:STATUS_ACCEPTED;
             response.setHeader(CONTENT_LOCATION, string `${localhost}${testServerBaseUrl}/exportStatus/1`);
+            response.setHeader(CONTENT_TYPE, FHIR_JSON);
+            response.setPayload({ "status": "in-progress" }, FHIR_JSON);
             return response;
         }
 
@@ -349,11 +353,13 @@ http:Service FhirMockService = service object {
         return response;
     }
 
-    resource function get Group/[string id]/[string export]() returns http:Response {
+    resource function get Group/[string id]/[string 'type]() returns http:Response {
         http:Response response = new ();
-        if export == EXPORT {
+        if 'type == EXPORT {
             response.statusCode = http:STATUS_ACCEPTED;
             response.setHeader(CONTENT_LOCATION, string `${localhost}${testServerBaseUrl}/exportStatus/1`);
+            response.setHeader(CONTENT_TYPE, FHIR_JSON);
+            response.setPayload({ "status": "in-progress" }, FHIR_JSON);
             return response;
         }
         response.statusCode = http:STATUS_NOT_FOUND;
@@ -365,7 +371,9 @@ http:Service FhirMockService = service object {
         http:Response response = new ();
         if id == "1" {
             response.statusCode = http:STATUS_ACCEPTED;
-            response.setHeader("X-Progress", "Build in progress - Status set to BUILDING ");
+            response.setHeader(X_PROGRESS, "Build in progress - Status set to BUILDING ");
+            response.setHeader(CONTENT_TYPE, FHIR_JSON);
+            response.setPayload({ "status": "in-progress" }, FHIR_JSON);
         } else {
             response.statusCode = http:STATUS_OK;
             response.setPayload(testExportFileManifestData, FHIR_JSON);

--- a/fhir/tests/test.bal
+++ b/fhir/tests/test.bal
@@ -33,7 +33,17 @@ FHIRConnectorConfig urlRewriteConfig = {
     baseURL: localhost + testServerBaseUrl,
     mimeType: FHIR_JSON,
     urlRewrite: true,
-    replacementURL: replacementUrl
+    replacementURL: replacementUrl, 
+    bulkFileServerConfig: {
+        temporaryDirectory: string `target${Path_Seperator}bulk_export_files`,
+        targetServerConfig: {
+            username: "",
+            password: "",
+            host: localhost,
+            'type: "fhir",
+            directory: "/target/bulk_files"
+        }
+    }
 };
 FHIRConnector urlRewriteConnector = check new (urlRewriteConfig);
 
@@ -70,7 +80,7 @@ function testUrlRewrite() returns FHIRError? {
 
     // Testing URL rewrite on headers
     FHIRResponse res5 = check urlRewriteConnector->bulkExport(EXPORT_SYSTEM);
-    string rewrittenPollingUrl = res5.serverResponseHeaders[CONTENT_LOCATION] ?: "";
+    string rewrittenPollingUrl = res5.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] ?: "";
     test:assertEquals(rewrittenPollingUrl, string `${replacementUrl}/exportStatus/1`, "Failed to url rewrite headers");
 
 }
@@ -511,17 +521,17 @@ function testBulkExportKickOff() returns FHIRError? {
     // System export kick off
     FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
     test:assertEquals(result1.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result1.serverResponseHeaders[CONTENT_LOCATION] != (), "Failed to return bulk export content location header");
+    test:assertTrue(result1.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] != (), "Failed to return bulk export content location header");
 
     // Patient level export kick off
     FHIRResponse result2 = check fhirConnector->bulkExport(EXPORT_PATIENT);
     test:assertEquals(result2.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result2.serverResponseHeaders[CONTENT_LOCATION] != (), "Failed to return bulk export content location header");
+    test:assertTrue(result2.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] != (), "Failed to return bulk export content location header");
 
     // Export group kick off
     FHIRResponse result3 = check fhirConnector->bulkExport(EXPORT_GROUP, "123");
     test:assertEquals(result3.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result3.serverResponseHeaders[CONTENT_LOCATION] != (), "Failed to return bulk export content location header");
+    test:assertTrue(result3.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] != (), "Failed to return bulk export content location header");
 
     // Export group kick off with no group id
     FHIRResponse|FHIRError result4 = fhirConnector->bulkExport(EXPORT_GROUP);
@@ -543,19 +553,19 @@ function testBulkExportKickOff() returns FHIRError? {
     FHIRResponse result5 = check fhirConnector->bulkExport(
         EXPORT_SYSTEM,
         bulkExportParameters = {
-        _since: "2017-01-01T00:00:00Z",
-        _type: ["Patient"]
-    }
+            _since: "2017-01-01T00:00:00Z",
+            _type: ["Patient"]
+        }
     );
     test:assertEquals(result5.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result5.serverResponseHeaders[CONTENT_LOCATION] != (), "Failed to return bulk export content location header");
+    test:assertTrue(result5.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] != (), "Failed to return bulk export content location header");
 }
 
 @test:Config {}
 function testBulkExportStatus() returns FHIRError? {
     // System export kick off
     FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
-    string pollingUrl = result1.serverResponseHeaders[CONTENT_LOCATION] ?: "";
+    string pollingUrl = result1.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] ?: "";
 
     // Polling the export status
     FHIRResponse result2 = check fhirConnector->bulkStatus(pollingUrl);
@@ -577,7 +587,7 @@ function testBulkExportStatus() returns FHIRError? {
 function testBulkExportCancel() returns FHIRError? {
     // System export kick off
     FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
-    string pollingUrl = result1.serverResponseHeaders[CONTENT_LOCATION] ?: "";
+    string pollingUrl = result1.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] ?: "";
 
     // Cancel the export
     FHIRResponse result2 = check fhirConnector->bulkDataDelete(pollingUrl);

--- a/fhir/tests/test.bal
+++ b/fhir/tests/test.bal
@@ -25,7 +25,15 @@ final string replacementUrl = "http://localhost:8181/fhir";
 
 FHIRConnectorConfig config = {
     baseURL: localhost + testServerBaseUrl,
-    mimeType: FHIR_JSON
+    mimeType: FHIR_JSON, 
+    bulkFileServerConfig: {
+        defaultIntervalInSec: 0.5d,
+        username: "",
+        password: "",
+        host: localhost,
+        'type: "fhir",
+        directory: "/target/bulk_files"
+    }
 };
 FHIRConnector fhirConnector = check new (config);
 
@@ -33,16 +41,14 @@ FHIRConnectorConfig urlRewriteConfig = {
     baseURL: localhost + testServerBaseUrl,
     mimeType: FHIR_JSON,
     urlRewrite: true,
-    replacementURL: replacementUrl, 
+    replacementURL: replacementUrl,
     bulkFileServerConfig: {
-        temporaryDirectory: string `target${Path_Seperator}bulk_export_files`,
-        targetServerConfig: {
-            username: "",
-            password: "",
-            host: localhost,
-            'type: "fhir",
-            directory: "/target/bulk_files"
-        }
+        defaultIntervalInSec: 0.5d,
+        username: "",
+        password: "",
+        host: localhost,
+        'type: "fhir",
+        directory: "/target/bulk_files1"
     }
 };
 FHIRConnector urlRewriteConnector = check new (urlRewriteConfig);
@@ -523,11 +529,6 @@ function testBulkExportKickOff() returns FHIRError? {
     test:assertEquals(result1.httpStatusCode, 202, "Failed to return the correct status code");
     test:assertTrue(result1.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] != (), "Failed to return bulk export content location header");
 
-    // Patient level export kick off
-    FHIRResponse result2 = check fhirConnector->bulkExport(EXPORT_PATIENT);
-    test:assertEquals(result2.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result2.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] != (), "Failed to return bulk export content location header");
-
     // Export group kick off
     FHIRResponse result3 = check fhirConnector->bulkExport(EXPORT_GROUP, "123");
     test:assertEquals(result3.httpStatusCode, 202, "Failed to return the correct status code");
@@ -647,6 +648,47 @@ function testBulkExportFileAccess() returns error? {
     } else {
         test:assertFail("Failed to respond with the correct error");
     }
+}
+
+@test:Config {
+    dependsOn: [
+        testBulkExportKickOff,
+        testBulkExportStatus,
+        testBulkExportFileAccess,
+        testBulkExportCancel
+    ]
+}
+function testBulkExportFullProcess() returns error? {
+    // Patient level export kick off
+    FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_PATIENT);
+    test:assertEquals(result1.httpStatusCode, 202, "Failed to return the correct status code");
+    test:assertTrue(result1.serverResponseHeaders[CONTENT_LOCATION.toLowerAscii()] != (), "Failed to return bulk export content location header");
+    json responseBody = result1.'resource.toJson();
+    Export exportResult = {
+        exportId: check responseBody.exportId,
+        pollingUrl: check responseBody.pollingUrl
+    };
+
+    // Patient level export status check
+    FHIRResponse result2 = check fhirConnector->bulkStatus(exportId = exportResult.exportId);
+    test:assertEquals(result2.httpStatusCode, 202, "Failed to return the correct status code");
+
+    // wait for the export to complete
+    waitForBulkExportCompletion(exportResult.exportId);
+
+    // Patient level export status check: not found after completion
+    FHIRResponse|FHIRError result3 = fhirConnector->bulkStatus(exportId = exportResult.exportId);
+    test:assertTrue(result3 is FHIRError, "Expected an error response after export completion");
+
+    check createExportFile(exportResult.exportId);
+
+    // get the files, should be assign to a variable to use later
+    FHIRBulkFileResponse result4 = check fhirConnector->bulkFile(exportId = exportResult.exportId, resourceType = PATIENT);
+    test:assertEquals(result4.httpStatusCode, 200, "Failed to return the correct status code for bulk file access");
+    
+    // delete the files from the memory
+    FHIRResponse result5 = check fhirConnector->bulkDataDelete(exportId = exportResult.exportId);
+    test:assertEquals(result5.httpStatusCode, 200, "Failed to return the correct status code for bulk data delete");
 }
 
 @test:Config {}

--- a/fhir/tests/test.bal
+++ b/fhir/tests/test.bal
@@ -70,7 +70,7 @@ function testUrlRewrite() returns FHIRError? {
 
     // Testing URL rewrite on headers
     FHIRResponse res5 = check urlRewriteConnector->bulkExport(EXPORT_SYSTEM);
-    string rewrittenPollingUrl = res5.serverResponseHeaders["content-location"] ?: "";
+    string rewrittenPollingUrl = res5.serverResponseHeaders[CONTENT_LOCATION] ?: "";
     test:assertEquals(rewrittenPollingUrl, string `${replacementUrl}/exportStatus/1`, "Failed to url rewrite headers");
 
 }
@@ -511,17 +511,17 @@ function testBulkExportKickOff() returns FHIRError? {
     // System export kick off
     FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
     test:assertEquals(result1.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result1.serverResponseHeaders["content-location"] != (), "Failed to return bulk export content location header");
+    test:assertTrue(result1.serverResponseHeaders[CONTENT_LOCATION] != (), "Failed to return bulk export content location header");
 
     // Patient level export kick off
     FHIRResponse result2 = check fhirConnector->bulkExport(EXPORT_PATIENT);
     test:assertEquals(result2.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result2.serverResponseHeaders["content-location"] != (), "Failed to return bulk export content location header");
+    test:assertTrue(result2.serverResponseHeaders[CONTENT_LOCATION] != (), "Failed to return bulk export content location header");
 
     // Export group kick off
     FHIRResponse result3 = check fhirConnector->bulkExport(EXPORT_GROUP, "123");
     test:assertEquals(result3.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result3.serverResponseHeaders["content-location"] != (), "Failed to return bulk export content location header");
+    test:assertTrue(result3.serverResponseHeaders[CONTENT_LOCATION] != (), "Failed to return bulk export content location header");
 
     // Export group kick off with no group id
     FHIRResponse|FHIRError result4 = fhirConnector->bulkExport(EXPORT_GROUP);
@@ -548,14 +548,14 @@ function testBulkExportKickOff() returns FHIRError? {
     }
     );
     test:assertEquals(result5.httpStatusCode, 202, "Failed to return the correct status code");
-    test:assertTrue(result5.serverResponseHeaders["content-location"] != (), "Failed to return bulk export content location header");
+    test:assertTrue(result5.serverResponseHeaders[CONTENT_LOCATION] != (), "Failed to return bulk export content location header");
 }
 
 @test:Config {}
 function testBulkExportStatus() returns FHIRError? {
     // System export kick off
     FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
-    string pollingUrl = result1.serverResponseHeaders["content-location"] ?: "";
+    string pollingUrl = result1.serverResponseHeaders[CONTENT_LOCATION] ?: "";
 
     // Polling the export status
     FHIRResponse result2 = check fhirConnector->bulkStatus(pollingUrl);
@@ -577,7 +577,7 @@ function testBulkExportStatus() returns FHIRError? {
 function testBulkExportCancel() returns FHIRError? {
     // System export kick off
     FHIRResponse result1 = check fhirConnector->bulkExport(EXPORT_SYSTEM);
-    string pollingUrl = result1.serverResponseHeaders["content-location"] ?: "";
+    string pollingUrl = result1.serverResponseHeaders[CONTENT_LOCATION] ?: "";
 
     // Cancel the export
     FHIRResponse result2 = check fhirConnector->bulkDataDelete(pollingUrl);

--- a/fhir/tests/test_utils.bal
+++ b/fhir/tests/test_utils.bal
@@ -1,0 +1,49 @@
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.runtime;
+import ballerina/file;
+import ballerina/log;
+import ballerina/io;
+
+isolated boolean isEndOfExport = false;
+
+type Export record {
+    string exportId;
+    string pollingUrl;
+};
+
+isolated function waitForPatientExport() {
+    worker waitForExport {
+        runtime:sleep(3);
+    }
+
+    wait waitForExport;
+
+    lock {
+        isEndOfExport = true;
+    }
+}
+
+isolated function createExportFile(string exportId) returns error? {
+    string fileName = DEFAULT_EXPORT_DIRECTORY + Path_Seperator + exportId + Path_Seperator + PATIENT + "-exported.ndjson";
+    check file:createDir(DEFAULT_EXPORT_DIRECTORY + Path_Seperator + exportId, file:RECURSIVE);
+    check file:create(fileName);
+    
+    log:printDebug("Export file created successfully.", fileName = fileName);
+
+    check io:fileWriteBytes(fileName, testBulkExportFileData.toBytes());
+}

--- a/fhir/utils.bal
+++ b/fhir/utils.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
## Purpose
This PR introduces robust asynchronous bulk export capabilities to the FHIR client, including in-memory tracking of export tasks and improved file management for exported data.

## Goals

- Implement async bulk export operations, allowing users to initiate, monitor, and retrieve large FHIR datasets without blocking the main thread.
- Add in-memory storage for export task status, enabling efficient polling, progress tracking, and management of multiple concurrent export jobs.
- Provide utility functions for polling export status, downloading exported files, and cleaning up resources.
- Expose a waitForBulkExportCompletion function for blocking until export completion in standalone scenarios, while supporting non-blocking usage in service-based applications.
- Enhance documentation and examples to demonstrate async export workflows and in-memory task management.
- Ensure seamless integration with both HTTP and FTP file servers for flexible export file handling.

## Approach

- Asynchronous Export: Bulk export operations are now fully async, with background polling and file download jobs managed independently of the main application flow.
- In-Memory Task Storage: Export tasks and their statuses are tracked in memory, supporting real-time status checks and efficient resource cleanup.
- Flexible Usage: Developers can choose between blocking and non-blocking patterns for export completion, depending on their application needs.


## Automation tests
 - Unit tests 
   Coverage: 75.67%
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

    import ballerinax/health.clients.fhir as fhir_client;
    
    fhir_client:BulkFileServerConfig bulkFileServerConfig = {
        'type: "fhir", 
        host: "eu-central-1.sftpcloud.io",
        directory: "/target/files", 
        username: "<username>",
        password: "<password>"
    };
    
    fhir_client:FHIRConnectorConfig fhirServerConfig = {
        baseURL: "https://bulk-data.smarthealthit.org/fhir",
        mimeType: fhir_client:FHIR_JSON, 
        bulkFileServerConfig: bulkFileServerConfig
    };
    
    fhir_client:FHIRConnector fhirConnector = check new (fhirServerConfig);
    
    public function main() returns error? {
        // Start bulk export
        fhir_client:FHIRResponse response = check fhirConnector->bulkExport(fhir_client:EXPORT_PATIENT);
        json responseBody = response.'resource.toJson();
        string exportId = check responseBody.exportId;
    
        // Wait for export to complete (only needed in standalone/main)
        fhir_client:waitForBulkExportCompletion(exportId);
    
        // Download exported files
        _ = check fhirConnector->bulkFile(exportId = exportId, resourceType = fhir_client:PATIENT);
    
        // Delete exported files from server
        _ = check fhirConnector->bulkDataDelete(exportId = exportId);
    }

## Test environment

- JDK: openjdk 21.0.6
- Ballerina: 2201.12.3
- OS: Windows 11
