### PR TITLE
Refactor regex usage in FHIR client functions

### DIFF
--- a/fhir/Dependencies.toml
+++ b/fhir/Dependencies.toml
@@ -292,18 +292,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "regex"
-version = "1.4.3"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.string"}
-]
-modules = [
-	{org = "ballerina", packageName = "regex", moduleName = "regex"}
-]
-
-[[package]]
-org = "ballerina"
 name = "task"
 version = "2.10.0"
 dependencies = [
@@ -408,7 +396,6 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "regex"},
 	{org = "ballerina", name = "task"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"},

--- a/fhir/utils.bal
+++ b/fhir/utils.bal
@@ -16,7 +16,6 @@
 
 import ballerina/http;
 import ballerina/log;
-import ballerina/regex;
 import ballerina/url;
 
 isolated function setFormatNSummaryParameters(MimeType? mimeType, SummaryType? summary) returns string {
@@ -634,14 +633,15 @@ isolated function sanitizeRequestUrl(string url) returns string {
     return url.endsWith(AMPERSAND) || url.endsWith(QUESTION_MARK) ? url.substring(0, url.length() - 1) : url;
 }
 
+// regex in FHIR client
 isolated function matchesQueryPattern(string input) returns boolean {
     // Regex: key=value[&key=value]*
-    string pattern = "^[^=&?]+=[^=&]+(?:&[^=&?]+=[^=&]+)*$";
-    return regex:matches(input, pattern);
+    string:RegExp pattern = re `^[^=&?]+=[^=&]+(?:&[^=&?]+=[^=&]+)*$`;
+    return pattern.isFullMatch(input);
 }
 
 isolated function isSupportedFhirVersion(string fhirVersion) returns boolean {
     // Accepts FHIR versions R4 (4.x.x) and onwards (e.g., 4.0.1, 5.0.0)
-    string versionPattern = "^(4|5)\\.[0-9]+\\.[0-9]+$";
-    return regex:matches(fhirVersion, versionPattern);
+    string:RegExp versionPattern = re `^(4|5)\.[0-9]+\.[0-9]+$`;
+    return versionPattern.isFullMatch(fhirVersion);
 }


### PR DESCRIPTION
## Purpose
- To replace the regex usage in FHIR client functions by using new `ballerina/lang.regexp` package.